### PR TITLE
feat: release on specific labels

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -35,9 +35,9 @@ version-resolver:
   minor:
     labels:
       - 'enhancement'
+      - 'fix'
   patch:
     labels:
-      - 'fix'
       - 'documentation'
       - 'maintenance'
   default: patch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@
 
   on:
     workflow_dispatch:
-    push:
+    pull_request:
+      types:
+        - closed
       branches:
         - main
 
@@ -12,6 +14,16 @@
 
   jobs:
     create_release:
+      # release if
+      # manual deployment OR
+      # merged to main and labelled with release labels
+      if: |
+        (github.event_name == 'workflow_dispatch') ||
+        (github.event.pull_request.merged == true &&
+        (contains(github.event.pull_request.labels.*.name, 'breaking') ||
+        contains(github.event.pull_request.labels.*.name, 'enhancement') ||
+        contains(github.event.pull_request.labels.*.name, 'vuln') ||
+        contains(github.event.pull_request.labels.*.name, 'release')))
       outputs:
         full-tag: ${{ steps.release-drafter.outputs.tag_name }}
         short-tag: ${{ steps.get_tag_name.outputs.SHORT_TAG }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,4 +78,6 @@ We are using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.
 
 ## Releases
 
-Releases are automated but if you need to manually initiate a release you can do so through the GitHub Actions UI.  If you have permissions to do so, you can navigate to the [Actions tab](https://github.com/github/contributors/actions/workflows/release.yml) and select the `Run workflow` button.  This will allow you to select the branch to release from and the version to release.
+Releases are automated if a pull request is labelled with our [SemVer related labels](.github/release-drafter.yml) or with the `vuln` or `release` labels.
+
+You can also manually initiate a release you can do so through the GitHub Actions UI.  If you have permissions to do so, you can navigate to the [Actions tab](https://github.com/github/contributors/actions/workflows/release.yml) and select the `Run workflow` button.  This will allow you to select the branch to release from and the version to release.


### PR DESCRIPTION
Related to https://github.com/github/github-ospo/issues/105

# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

Only generate a release and new action container images if our semver related labels (`breaking`, `enhancement`, `fix`) or the `release` label are used on a merged pull request.

Changed from push (merge) on main branch to release generation happening when a pull_request is merged to main branch.

This gives us access to the pull requests labels without having to make API cals.

Currently we'd still need to label a pull request with `release` if it is a dependabot or manual pull request related to a CVE or security fix.

- [x] update CONTRIBUTING.md with new release information
- [x] manually add `vuln` and `release` labels to repository

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
