### PR TITLE
fix: skip date validation when env variable not set

### DIFF
--- a/env.py
+++ b/env.py
@@ -47,6 +47,8 @@ def get_int_env_var(env_var_name: str) -> int | None:
 def validate_date_format(env_var_name: str) -> str:
     """Validate the date format of the environment variable.
 
+    Does nothing if the environment variable is not set.
+
     Args:
         env_var_name: The name of the environment variable to retrieve.
 
@@ -54,6 +56,10 @@ def validate_date_format(env_var_name: str) -> str:
         The value of the environment variable as a string.
     """
     date_to_validate = os.getenv(env_var_name, "")
+
+    if not date_to_validate:
+        return date_to_validate
+
     pattern = "%Y-%m-%d"
     try:
         datetime.datetime.strptime(date_to_validate, pattern)

--- a/test_env.py
+++ b/test_env.py
@@ -136,6 +136,55 @@ class TestEnv(unittest.TestCase):
             "START_DATE environment variable not in the format YYYY-MM-DD",
         )
 
+    @patch.dict(
+        os.environ,
+        {
+            "ORGANIZATION": "org",
+            "REPOSITORY": "repo,repo2",
+            "GH_APP_ID": "",
+            "GH_APP_INSTALLATION_ID": "",
+            "GH_APP_PRIVATE_KEY": "",
+            "GH_TOKEN": "token",
+            "GH_ENTERPRISE_URL": "",
+            "START_DATE": "",
+            "END_DATE": "",
+            "SPONSOR_INFO": "False",
+            "LINK_TO_PROFILE": "True",
+        },
+        clear=True,
+    )
+    def test_get_env_vars_no_dates(self):
+        """
+        Test the get_env_vars function when all environment variables are set correctly
+        and start_date and end_date are not set.
+        """
+
+        (
+            organization,
+            repository_list,
+            gh_app_id,
+            gh_app_installation_id,
+            gh_app_private_key_bytes,
+            token,
+            ghe,
+            start_date,
+            end_date,
+            sponsor_info,
+            link_to_profile,
+        ) = env.get_env_vars()
+
+        self.assertEqual(organization, "org")
+        self.assertEqual(repository_list, ["repo", "repo2"])
+        self.assertIsNone(gh_app_id)
+        self.assertIsNone(gh_app_installation_id)
+        self.assertEqual(gh_app_private_key_bytes, b"")
+        self.assertEqual(token, "token")
+        self.assertEqual(ghe, "")
+        self.assertEqual(start_date, "")
+        self.assertEqual(end_date, "")
+        self.assertFalse(sponsor_info)
+        self.assertTrue(link_to_profile)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes
Skip date validation when the respective environment variable is set. Currently, omitting the dates causes the action to fail, so it's impossible to output a report that does not include whether a user is a new contributor.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
