### PR TITLE
#268 Fix LINK_TO_PROFILE

### DIFF
--- a/markdown.py
+++ b/markdown.py
@@ -191,7 +191,7 @@ def get_contributor_table(
                 commit_urls += f"{url}, "
         new_contributor = collaborator.new_contributor
 
-        row = f"| {'' if link_to_profile == 'false' else '@'}{username} | {contribution_count} |"
+        row = f"| {'' if not link_to_profile else '@'}{username} | {contribution_count} |"
         if "New Contributor" in columns:
             row += f" {new_contributor} |"
         if "Sponsor URL" in columns:


### PR DESCRIPTION
LINK_TO_PROFILE is being read and set as boolean but compared against string

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `make lint` and fix any issues that you have introduced
- [ ] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
