### PR TITLE
fix: go back to using root user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 #checkov:skip=CKV_DOCKER_2
 #checkov:skip=CKV_DOCKER_3
+#trivy:ignore:AVD-DS-0002
 FROM python:3.13.7-slim@sha256:58c30f5bfaa718b5803a53393190b9c68bd517c44c6c94c1b6c8c172bcfad040
 LABEL com.github.actions.name="contributors" \
     com.github.actions.description="GitHub Action that given an organization or repository, produces information about the contributors over the specified time period." \
@@ -18,13 +19,7 @@ COPY requirements.txt *.py /action/workspace/
 RUN python3 -m pip install --no-cache-dir -r requirements.txt \
     && apt-get -y update \
     && apt-get -y install --no-install-recommends git=1:2.47.3-0+deb13u1 \
-    && rm -rf /var/lib/apt/lists/* \
-    && addgroup --system appuser \
-    && adduser --system --ingroup appuser --home /action/workspace --disabled-login appuser \
-    && chown -R appuser:appuser /action/workspace
-
-# Run the action as a non-root user
-USER appuser
+    && rm -rf /var/lib/apt/lists/*
 
 # Add a simple healthcheck to satisfy container scanners
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

We have to do this because we have no active way to change permissions to $GITHUB_OUTPUT to a specific user when running the container

Add trivy ignore to top of Dockerfile to pass linting

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
