### PR TITLE
docs: add repository relocation banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Contributors action
+
 > [!IMPORTANT]
 > This repository has moved from `github/contributors` to `github-community-projects/contributors`.
 > Please update your git remote:
@@ -7,8 +9,6 @@
 > ```
 >
 > Note: replace `origin` with the name of your remote if it's different.
-
-# Contributors action
 
 [![Python package](https://github.com/github-community-projects/contributors/actions/workflows/python-ci.yml/badge.svg)](https://github.com/github-community-projects/contributors/actions/workflows/python-ci.yml)
 [![Docker Image CI](https://github.com/github-community-projects/contributors/actions/workflows/docker-ci.yml/badge.svg)](https://github.com/github-community-projects/contributors/actions/workflows/docker-ci.yml)


### PR DESCRIPTION
## What

Added an important notice banner at the top of the README informing users that the repository has moved from `github/contributors` to `github-community-projects/contributors`, with instructions to update their git remote.

## Why

Users with existing clones still pointing at the old github/contributors remote need a clear, visible notification about the move and a copy-paste command to update their remote URL.

## Notes

- Uses GitHub's `[!IMPORTANT]` alert syntax which only renders on GitHub — won't display as a callout in other markdown renderers

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
