### PR TITLE
chore: update CODEOWNERS to individual maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @github/ospo-github-actions
+* @zkoppert @jmeridth


### PR DESCRIPTION
## What

Replaced the github/ospo-github-actions team with @zkoppert and @jmeridth as code owners.

## Why

The repository has moved to the github-community-projects org which does not have the github/ospo-github-actions team. Ownership needs to reflect the actual individual maintainers.

## Notes

- The old team @github/ospo-github-actions will no longer receive review requests for PRs in this repo
- Any branch protection rules requiring CODEOWNERS approval will now route to these two individuals

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [ ] run `make lint` and fix any issues that you have introduced
- [ ] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
