### PR TITLE
fix: store new_contributor parameter in __init__

### DIFF
--- a/contributor_stats.py
+++ b/contributor_stats.py
@@ -23,11 +23,11 @@ class ContributorStats:
 
     Attributes:
         username (str): The username of the contributor
-        new_contributor (bool): Whether the contributor is new or returning
         avatar_url (str): The url of the contributor's avatar
         contribution_count (int): The number of contributions the contributor has made
         commit_url (str): The url of the contributor's commits
         sponsor_info (str): The url of the contributor's sponsor page
+        new_contributor (bool): Whether the contributor is new or returning
 
     """
 
@@ -38,29 +38,29 @@ class ContributorStats:
     def __init__(
         self,
         username: str,
-        new_contributor: bool,
         avatar_url: str,
         contribution_count: int,
         commit_url: str,
         sponsor_info: str,
+        new_contributor: bool = False,
     ):
         """Initialize the contributor_stats object"""
         self.username = username
-        self.new_contributor = new_contributor
         self.avatar_url = avatar_url
         self.contribution_count = contribution_count
         self.commit_url = commit_url
         self.sponsor_info = sponsor_info
+        self.new_contributor = new_contributor
 
     def __repr__(self) -> str:
         """Return the representation of the contributor_stats object"""
         return (
             f"contributor_stats(username={self.username}, "
-            f"new_contributor={self.new_contributor}, "
             f"avatar_url={self.avatar_url}, "
             f"contribution_count={self.contribution_count}, "
             f"commit_url={self.commit_url}, "
-            f"sponsor_info={self.sponsor_info})"
+            f"sponsor_info={self.sponsor_info}, "
+            f"new_contributor={self.new_contributor})"
         )
 
     def __eq__(self, other) -> bool:

--- a/contributors.py
+++ b/contributors.py
@@ -181,7 +181,6 @@ def get_contributors(repo: object, start_date: str, end_date: str, ghe: str):
                 commit_url = f"{endpoint}/{repo.full_name}/commits?author={username}&since={start_date}&until={end_date}"
                 contributor = contributor_stats.ContributorStats(
                     username,
-                    False,
                     data["avatar_url"],
                     data["contribution_count"],
                     commit_url,
@@ -195,7 +194,6 @@ def get_contributors(repo: object, start_date: str, end_date: str, ghe: str):
                 commit_url = f"{endpoint}/{repo.full_name}/commits?author={user.login}"
                 contributor = contributor_stats.ContributorStats(
                     user.login,
-                    False,
                     user.avatar_url,
                     user.contributions_count,
                     commit_url,

--- a/test_contributor_stats.py
+++ b/test_contributor_stats.py
@@ -22,12 +22,25 @@ class TestContributorStats(unittest.TestCase):
         """
         self.contributor = ContributorStats(
             "zkoppert",
-            False,
             "https://avatars.githubusercontent.com/u/29484535?v=4",
             1261,
             "commit_url5",
             "",
         )
+
+    def test_init_new_contributor_true(self):
+        """
+        Test that new_contributor=True is preserved by __init__.
+        """
+        contributor = ContributorStats(
+            "new_user",
+            avatar_url="https://example.com/avatar.png",
+            contribution_count=1,
+            commit_url="commit_url_new",
+            sponsor_info="",
+            new_contributor=True,
+        )
+        self.assertTrue(contributor.new_contributor)
 
     def test_init(self):
         """
@@ -49,11 +62,11 @@ class TestContributorStats(unittest.TestCase):
         """Test the __repr__ method includes key fields."""
         expected = (
             "contributor_stats(username=zkoppert, "
-            "new_contributor=False, "
             "avatar_url=https://avatars.githubusercontent.com/u/29484535?v=4, "
             "contribution_count=1261, "
             "commit_url=commit_url5, "
-            "sponsor_info=)"
+            "sponsor_info=, "
+            "new_contributor=False)"
         )
         self.assertEqual(repr(self.contributor), expected)
 
@@ -63,7 +76,6 @@ class TestContributorStats(unittest.TestCase):
         """
         contributor1 = ContributorStats(
             "user1",
-            False,
             "https://avatars.githubusercontent.com/u/29484535?v=4",
             100,
             "commit_url1",
@@ -71,7 +83,6 @@ class TestContributorStats(unittest.TestCase):
         )
         contributor2 = ContributorStats(
             "user2",
-            False,
             "https://avatars.githubusercontent.com/u/29484535?v=4",
             200,
             "commit_url2",
@@ -79,7 +90,6 @@ class TestContributorStats(unittest.TestCase):
         )
         contributor3 = ContributorStats(
             "user1",
-            False,
             "https://avatars.githubusercontent.com/u/29484535?v=4",
             150,
             "commit_url3",
@@ -95,7 +105,6 @@ class TestContributorStats(unittest.TestCase):
         expected_result = [
             ContributorStats(
                 "user1",
-                False,
                 "https://avatars.githubusercontent.com/u/29484535?v=4",
                 250,
                 "commit_url1, commit_url3",
@@ -103,7 +112,6 @@ class TestContributorStats(unittest.TestCase):
             ),
             ContributorStats(
                 "user2",
-                False,
                 "https://avatars.githubusercontent.com/u/29484535?v=4",
                 200,
                 "commit_url2",
@@ -123,7 +131,6 @@ class TestContributorStats(unittest.TestCase):
         returning_contributors = [
             ContributorStats(
                 username="user1",
-                new_contributor=False,
                 avatar_url="https://avatars.githubusercontent.com/u/",
                 contribution_count=100,
                 commit_url="url1",
@@ -131,7 +138,6 @@ class TestContributorStats(unittest.TestCase):
             ),
             ContributorStats(
                 username="user2",
-                new_contributor=False,
                 avatar_url="https://avatars.githubusercontent.com/u/",
                 contribution_count=200,
                 commit_url="url2",
@@ -151,7 +157,6 @@ class TestContributorStats(unittest.TestCase):
         returning_contributors = [
             ContributorStats(
                 username="user1",
-                new_contributor=False,
                 avatar_url="https://avatars.githubusercontent.com/u/",
                 contribution_count=100,
                 commit_url="url1",
@@ -159,7 +164,6 @@ class TestContributorStats(unittest.TestCase):
             ),
             ContributorStats(
                 username="user2",
-                new_contributor=False,
                 avatar_url="https://avatars.githubusercontent.com/u/",
                 contribution_count=200,
                 commit_url="url2",
@@ -189,7 +193,6 @@ class TestContributorStats(unittest.TestCase):
         returning_contributors = [
             ContributorStats(
                 username=user,
-                new_contributor=False,
                 avatar_url="https://avatars.githubusercontent.com/u/",
                 contribution_count=100,
                 commit_url="url1",
@@ -237,7 +240,6 @@ class TestContributorStats(unittest.TestCase):
         contributors = [
             ContributorStats(
                 username="user1",
-                new_contributor=False,
                 avatar_url="https://avatars.githubusercontent.com/u/",
                 contribution_count=100,
                 commit_url="url1",

--- a/test_contributors.py
+++ b/test_contributors.py
@@ -37,7 +37,6 @@ class TestContributors(unittest.TestCase):
         )
         mock_contributor_stats.assert_called_once_with(
             "user",
-            False,
             "https://avatars.githubusercontent.com/u/12345678?v=4",
             1,
             "https://github.com/owner/repo/commits?author=user&since=2022-01-01&until=2022-12-31",
@@ -57,7 +56,6 @@ class TestContributors(unittest.TestCase):
         mock_get_contributors.return_value = [
             ContributorStats(
                 "user",
-                False,
                 "https://avatars.githubusercontent.com/u/29484535?v=4",
                 100,
                 "commit_url",
@@ -75,7 +73,6 @@ class TestContributors(unittest.TestCase):
             [
                 ContributorStats(
                     "user",
-                    False,
                     "https://avatars.githubusercontent.com/u/29484535?v=4",
                     200,
                     "commit_url, commit_url",
@@ -96,7 +93,6 @@ class TestContributors(unittest.TestCase):
         mock_get_contributors.return_value = [
             ContributorStats(
                 "user",
-                False,
                 "https://avatars.githubusercontent.com/u/29484535?v=4",
                 100,
                 "commit_url2",
@@ -114,7 +110,6 @@ class TestContributors(unittest.TestCase):
             [
                 ContributorStats(
                     "user",
-                    False,
                     "https://avatars.githubusercontent.com/u/29484535?v=4",
                     100,
                     "commit_url2",
@@ -152,7 +147,6 @@ class TestContributors(unittest.TestCase):
         )
         mock_contributor_stats.assert_called_once_with(
             "user",
-            False,
             "https://avatars.githubusercontent.com/u/12345678?v=4",
             1,
             "https://github.com/owner/repo/commits?author=user&since=2022-01-01&until=2022-12-31",
@@ -203,7 +197,6 @@ class TestContributors(unittest.TestCase):
         mock_repo.commits.assert_not_called()
         mock_contributor_stats.assert_called_once_with(
             "user",
-            False,
             "https://avatars.githubusercontent.com/u/12345678?v=4",
             100,
             "https://github.com/owner/repo/commits?author=user",
@@ -338,7 +331,6 @@ class TestContributors(unittest.TestCase):
         """Test main sets new_contributor when start/end dates are provided."""
         contributor = ContributorStats(
             "user1",
-            False,
             "https://avatars.githubusercontent.com/u/1",
             10,
             "commit_url",
@@ -389,7 +381,6 @@ class TestContributors(unittest.TestCase):
         """Test main fetches sponsor information when sponsor_info is enabled."""
         contributor = ContributorStats(
             "user1",
-            False,
             "https://avatars.githubusercontent.com/u/1",
             10,
             "commit_url",
@@ -397,7 +388,6 @@ class TestContributors(unittest.TestCase):
         )
         sponsored_contributor = ContributorStats(
             "user1",
-            False,
             "https://avatars.githubusercontent.com/u/1",
             10,
             "commit_url",

--- a/test_json_writer.py
+++ b/test_json_writer.py
@@ -38,7 +38,6 @@ class TestWriteToJson(unittest.TestCase):
         contributors = (
             ContributorStats(
                 username="test_user",
-                new_contributor=False,
                 avatar_url="https://test_url.com",
                 contribution_count=10,
                 commit_url="https://test_commit_url.com",

--- a/test_markdown.py
+++ b/test_markdown.py
@@ -24,7 +24,6 @@ class TestMarkdown(unittest.TestCase):
         """
         person1 = contributor_stats.ContributorStats(
             "user1",
-            False,
             "url",
             100,
             "commit url",
@@ -32,7 +31,6 @@ class TestMarkdown(unittest.TestCase):
         )
         person2 = contributor_stats.ContributorStats(
             "user2",
-            False,
             "url2",
             200,
             "commit url2",
@@ -90,7 +88,6 @@ class TestMarkdown(unittest.TestCase):
         """
         person1 = contributor_stats.ContributorStats(
             "user1",
-            False,
             "url",
             100,
             "commit url",
@@ -98,7 +95,6 @@ class TestMarkdown(unittest.TestCase):
         )
         person2 = contributor_stats.ContributorStats(
             "user2",
-            False,
             "url2",
             200,
             "commit url2",
@@ -156,7 +152,6 @@ class TestMarkdown(unittest.TestCase):
         """
         person1 = contributor_stats.ContributorStats(
             "user1",
-            False,
             "https://avatars.example.com/user1.png",
             100,
             "commit url",
@@ -164,7 +159,6 @@ class TestMarkdown(unittest.TestCase):
         )
         person2 = contributor_stats.ContributorStats(
             "user2",
-            False,
             "https://avatars.example.com/user2.png",
             200,
             "commit url2",
@@ -225,7 +219,6 @@ class TestMarkdown(unittest.TestCase):
         """
         person1 = contributor_stats.ContributorStats(
             "user1",
-            False,
             "url",
             100,
             "commit url",
@@ -233,7 +226,6 @@ class TestMarkdown(unittest.TestCase):
         )
         person2 = contributor_stats.ContributorStats(
             "user2",
-            False,
             "url2",
             200,
             "commit url2",
@@ -290,7 +282,6 @@ class TestMarkdown(unittest.TestCase):
         """
         person1 = contributor_stats.ContributorStats(
             "user1",
-            False,
             "url",
             100,
             "commit url",
@@ -298,7 +289,6 @@ class TestMarkdown(unittest.TestCase):
         )
         person2 = contributor_stats.ContributorStats(
             "user2",
-            False,
             "url2",
             200,
             "commit url2",
@@ -350,7 +340,6 @@ class TestMarkdown(unittest.TestCase):
         """
         person1 = contributor_stats.ContributorStats(
             "user1",
-            False,
             "url",
             100,
             "https://github.com/org1/repo1/commits?author=user1",
@@ -358,7 +347,6 @@ class TestMarkdown(unittest.TestCase):
         )
         person2 = contributor_stats.ContributorStats(
             "user2",
-            False,
             "url2",
             200,
             "https://github.com/org2/repo2/commits?author=user2, "
@@ -463,7 +451,6 @@ class TestMarkdown(unittest.TestCase):
         """
         person1 = contributor_stats.ContributorStats(
             "user1",
-            False,
             "url",
             100,
             "commit url",
@@ -471,7 +458,6 @@ class TestMarkdown(unittest.TestCase):
         )
         person2 = contributor_stats.ContributorStats(
             "user2",
-            False,
             "url2",
             200,
             "commit url2",
@@ -525,7 +511,6 @@ class TestMarkdown(unittest.TestCase):
         """
         person1 = contributor_stats.ContributorStats(
             "user1",
-            False,
             "url",
             100,
             "https://github.example.com/org1/repo1/commits?author=user1",


### PR DESCRIPTION
## Summary

Remove the unconditional `new_contributor = False` reassignment in `ContributorStats.__init__` that caused the constructor parameter to be silently ignored.

## Problem

The `new_contributor` parameter passed to `ContributorStats.__init__` was immediately overwritten by `new_contributor = False` on line 51, making the parameter misleading and preventing callers from initializing instances with a known value.

## Fix

Remove the reassignment so `self.new_contributor` stores the passed-in value (which defaults to `False`).

Closes #406