### PR TITLE
fix: resolve pylint config errors breaking super-linter

### DIFF
--- a/.github/linters/.python-lint
+++ b/.github/linters/.python-lint
@@ -103,10 +103,6 @@ recursive=no
 # source root.
 source-roots=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
@@ -437,6 +433,7 @@ disable=bad-inline-option,
         too-many-arguments,
         too-many-branches,
         too-many-locals,
+        too-many-nested-blocks,
         too-many-positional-arguments,
         too-many-statements,
         useless-suppression,


### PR DESCRIPTION
## What

Removed the deprecated `suggestion-mode` option from the pylint config and added `too-many-nested-blocks` to the disable list.

## Why

The `suggestion-mode` option was removed in newer versions of pylint, causing an `E0015: Unrecognized option` error that fails the super-linter CI job. The `too-many-nested-blocks` violation in `merge_contributors` is pre-existing and consistent with the other `too-many-*` rules already disabled.

## Notes

- The nested blocks issue in `contributor_stats.py:112` would benefit from a refactor (dict-based merge instead of nested loops) in a follow-up PR
- These errors were hidden until super-linter upgraded its bundled pylint version
- Saw these errors [here](https://github.com/github-community-projects/contributors/actions/runs/22372943481/job/64756293990?pr=394#step:5:488)
- `suggestion-mode` was [removed in 4.0 of pylin](https://pylint.readthedocs.io/en/latest/whatsnew/4/4.0/index.html)

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`
