### PR TITLE
build: harden CI with frozen installs and octo-sts token federation

### DIFF
--- a/.github/chainguard/update-uv-lock.sts.yaml
+++ b/.github/chainguard/update-uv-lock.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: "repo:github-community-projects/contributors:pull_request"
+claim_pattern:
+  job_workflow_ref: "github-community-projects/contributors/.github/workflows/update-uv-lock.yml@.*"
+
+permissions:
+  contents: write

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -39,4 +39,4 @@ jobs:
         run: uv python install 3.14
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --frozen --python 3.14

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --frozen --python ${{ matrix.python-version }}
       - name: Lint with flake8 and pylint
         run: |
           make lint

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           enable-cache: true
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --frozen
       - name: Lint Code Base
         uses: super-linter/super-linter@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0
         env:

--- a/.github/workflows/update-uv-lock.yml
+++ b/.github/workflows/update-uv-lock.yml
@@ -7,18 +7,25 @@ on:
       - pyproject.toml
 
 permissions:
-  contents: write
-  pull-requests: write
+  id-token: write
 
 jobs:
   update-lock:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App token via octo-sts
+        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: github-community-projects/contributors
+          identity: update-uv-lock
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
-          persist-credentials: true
+          persist-credentials: true # Use the workflow temporary token from octo-sts to allow pushing changes back to the dependabot branch
+          token: ${{ steps.octo-sts.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
@@ -26,10 +33,10 @@ jobs:
       - name: Update uv.lock
         run: uv lock
 
-      - name: Commit updated lockfile
+      - name: Commit and push updated lockfile
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "octo-sts[bot]"
+          git config user.email "801323+octo-sts[bot]@users.noreply.github.com"
           git add uv.lock
           git diff --cached --quiet || git commit -s -m "chore(deps): update uv.lock"
           git push


### PR DESCRIPTION
## What

Add --frozen and --python flags to all CI uv sync calls, and replace
GITHUB_TOKEN with an octo-sts OIDC-federated token in the
update-uv-lock workflow so its commits trigger subsequent CI runs.

## Why

Without --frozen, uv sync silently re-resolves dependencies when
uv.lock is out of date, masking lockfile staleness in CI. Without
--python, the CI matrix may use the runner's default Python instead of
the intended version. Commits made with GITHUB_TOKEN do not trigger
subsequent workflow runs, so Dependabot PRs with uv.lock updates were
not getting CI checks on the lockfile commit.

## Notes

- python-ci.yml: uv sync --frozen --python ${{ matrix.python-version }}
- super-linter.yaml: uv sync --frozen
- copilot-setup-steps.yml: uv sync --frozen --python 3.14
- Trust policy in .github/chainguard/update-uv-lock.sts.yaml scoped to
  pull_request events with job_workflow_ref matching update-uv-lock.yml
- Requires octo-sts app installed on the org

# Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
