### PR TITLE
ci: add mark-ready-when-ready workflow

### DIFF
--- a/.github/workflows/mark-ready-when-ready.yml
+++ b/.github/workflows/mark-ready-when-ready.yml
@@ -1,0 +1,28 @@
+name: Mark PR Ready When Ready
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize]
+
+permissions:
+  checks: read
+  contents: write
+  pull-requests: write
+  statuses: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  mark-ready:
+    name: Mark as ready after successful checks
+    runs-on: ubuntu-latest
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'Mark Ready When Ready') &&
+      github.event.pull_request.draft == true
+    steps:
+      - name: Mark ready when ready
+        uses: kenyonj/mark-ready-when-ready@33b13c51ba23786efb933701ef253352baf05bdd # main (contents:write fix)
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds the [mark-ready-when-ready](https://github.com/kenyonj/mark-ready-when-ready) GitHub Action workflow.

When a draft PR has the **Mark Ready When Ready** label applied, this workflow:
1. Watches for all required checks to pass (two rounds with a pause between)
2. Verifies results via GraphQL API
3. Confirms no merge conflicts
4. Marks the PR as ready for review and removes the label

## Changes

- Adds `.github/workflows/mark-ready-when-ready.yml`
- Label `Mark Ready When Ready` has been created in this repo

## Notes

- Action pinned to SHA `33b13c5` (includes `contents: write` permission fix)
- Requires `contents: write` permission for `GITHUB_TOKEN` to call `markPullRequestReadyForReview`