### PR TITLE
fix: prevent dev dependency downloads at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
 ENV PYTHONUNBUFFERED=1
 
 CMD ["/action/workspace/contributors.py"]
-ENTRYPOINT ["uv", "run", "--project", "/action/workspace"]
+ENTRYPOINT ["uv", "run", "--no-dev", "--project", "/action/workspace"]


### PR DESCRIPTION
## Problem

The Dockerfile `ENTRYPOINT` uses `uv run` without `--no-dev`, causing it to re-sync the environment and download ~15MB of CI-only tools on every action invocation:

```
Downloading pygments (1.2MiB)
Downloading black (1.7MiB)
Downloading mypy (13.0MiB)
```

The build step correctly uses `uv sync --frozen --no-dev`, but `uv run` ignores that and resolves the full dependency graph including `[dependency-groups] dev`.

## Fix

One-line change - add `--no-dev` to the entrypoint:

```dockerfile
ENTRYPOINT ["uv", "run", "--no-dev", "--project", "/action/workspace"]
```

## Context

Same fix as https://github.com/github-community-projects/pr-conflict-detector/pull/41